### PR TITLE
Test all 256 possible byte values for bad padding

### DIFF
--- a/paddingoracle.py
+++ b/paddingoracle.py
@@ -182,7 +182,7 @@ class PaddingOracle(object):
             # trying until we exceed the max retry attempts (default is 3)
 
             while retries < self.max_retries and not successful:
-                for i in reversed(xrange(255)):
+                for i in reversed(xrange(256)):
 
                     # Fuzz the test byte
 


### PR DESCRIPTION
Fix an off by one error that caused the bust() method to fail to test the byte value 255.
